### PR TITLE
Shrink docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,80 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+.dockersetup: &dockersetup
+  docker:
+    - image: dcanumn/cabinet:shrink_docker_build
+  working_directory: /cabinet
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  # The python orb contains a set of prepackaged CircleCI configuration you can use repeatedly in your configuration files
+  # Orb commands and jobs help you with common scripting around a language/tool
+  # so you dont have to copy and paste it everywhere.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
+  python: circleci/python@1.5.0
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  build:
+    <<: *dockersetup
+    steps:
+      - checkout
+
+  test:
+    <<: *dockersetup
+    steps:
+      - checkout
+      - run:
+          name: Run CABINET
+          no_output_timeout: 1h
+          command: |
+            cd /cabinet
+            echo Build successful
+
+
+
+  build-and-test: # This is the name of the job, feel free to change it to better match what you're trying to do!
+    # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
+    # You can specify an image from Dockerhub or use one of the convenience images from CircleCI's Developer Hub
+    # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
+    # The executor is the environment in which the steps below will be executed - below will use a python 3.10.2 container
+    # Change the version below to your required version of python
+    docker:
+      - image: cimg/python:3.10.2
+    # Checkout the code as the first step. This is a dedicated CircleCI step.
+    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
+    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
+    # Then run your tests!
+    # CircleCI will report the results back to your VCS provider.
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+          # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
+          # pip-dependency-file: test-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
+      - run:
+          name: Run tests
+          # This assumes pytest is installed via the install-package step above
+          command: pytest
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  version: 1
+  build_and_test:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - test:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+          

--- a/Dockerfile
+++ b/Dockerfile
@@ -240,8 +240,6 @@ RUN cp /home/cabinet/run.py /home/cabinet/cabinet
 RUN cd /home/cabinet/ && pip install -r requirements.txt 
 RUN cd /home/cabinet/ && chmod 555 -R run.py bin src parameter-file-application.json parameter-file-container.json cabinet data
 RUN find /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet/3d_fullres -type f -name 'postprocessing.json' -exec chmod 666 {} \;
-
-# Remap ownership of files with UIDs above 65535 to user "cabinet" (excluding files in mounted locations)
-RUN find / -type f -uid +65535 -exec chown cabinet:cabinet {} \; -mount
+RUN chmod -R a+r /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet/3d_fullres
 
 ENTRYPOINT ["cabinet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ RUN apt-get update -qq \
     && rm -rf /var/lib/apt/lists/* \
     && echo "Downloading FSL ..." \
     && mkdir -p /opt/fsl-6.0.5.1 \
-    && curl -fsSL --retry 5 https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-6.0.5.1-centos7_64.tar.gz \
-    | tar -xz -C /opt/fsl-6.0.5.1 --strip-components 1 \
+    && curl -fsSL --retry 5 "https://s3.msi.umn.edu/cabinet-fsl-install/fsl-6.0.5.1-centos7_64.tar.gz" \
+    | tar -xz -C /opt/fsl-6.0.5.1 --no-same-owner  --strip-components 1 \
     --exclude "fsl/config" \
     --exclude "fsl/data/first" \
     --exclude "fsl/data/mist" \
@@ -68,6 +68,105 @@ RUN apt-get update -qq \
     --exclude "fsl/src" \
     --exclude "fsl/tcl" \
     --exclude "fsl/bin/FSLeyes" \
+    --exclude "fsl/bin/probtrackx2_gpu"  \
+    --exclude "fsl/bin/mist"  \
+    --exclude "fsl/bin/eddy_cuda8.0"  \
+    --exclude "fsl/bin/eddy_cuda10.2"  \
+    --exclude "fsl/bin/eddy_cuda9.1"  \
+    --exclude "fsl/bin/melodic"  \
+    --exclude "fsl/bin/eddy_openmp"  \
+    --exclude "fsl/bin/fabber_asl"  \
+    --exclude "fsl/bin/fabber_cest"  \
+    --exclude "fsl/bin/probtrackx2"  \
+    --exclude "fsl/bin/flameo"  \
+    --exclude "fsl/bin/run_mesh_utils"  \
+    --exclude "fsl/bin/fabber_dualecho"  \
+    --exclude "fsl/bin/fabber_dsc"  \
+    --exclude "fsl/bin/fabber_dce"  \
+    --exclude "fsl/bin/fdt_matrix_merge"  \
+    --exclude "fsl/bin/mvntool"  \
+    --exclude "fsl/bin/fabber"  \
+    --exclude "fsl/bin/fabber_dwi"  \
+    --exclude "fsl/bin/fabber_pet"  \
+    --exclude "fsl/bin/fabber_qbold"  \
+    --exclude "fsl/bin/fabber_t1"  \
+    --exclude "fsl/bin/surf_proj"  \
+    --exclude "fsl/bin/surf2surf"  \
+    --exclude "fsl/bin/probtrackx"  \
+    --exclude "fsl/bin/film_gls"  \
+    --exclude "fsl/bin/ftoz"  \
+    --exclude "fsl/bin/ttoz"  \
+    --exclude "fsl/bin/ttologp"  \
+    --exclude "fsl/bin/contrast_mgr"  \
+    --exclude "fsl/bin/qboot"  \
+    --exclude "fsl/bin/cluster"  \
+    --exclude "fsl/bin/xfibres"  \
+    --exclude "fsl/bin/dtifit"  \
+    --exclude "fsl/bin/vecreg"  \
+    --exclude "fsl/binfsl_mvlm"  \
+    --exclude "fsl/bin/new_invwarp"  \
+    --exclude "fsl/bin/mm"  \
+    --exclude "fsl/binfsl_regfilt"  \
+    --exclude "fsl/bin/pvmfit"  \
+    --exclude "fsl/binfsl_sbca"  \
+    --exclude "fsl/binfslsurfacemaths"  \
+    --exclude "fsl/binfsl_glm"  \
+    --exclude "fsl/bin/swe"  \
+    --exclude "fsl/binfsl_schurprod"  \
+    --exclude "fsl/bin/first_utils"  \
+    --exclude "fsl/bin/filmbabe"  \
+    --exclude "fsl/bin/surf2volume"  \
+    --exclude "fsl/bin/first"  \
+    --exclude "fsl/bin/find_the_biggest"  \
+    --exclude "fsl/bin/feat_model"  \
+    --exclude "fsl/bin/tsplot"  \
+    --exclude "fsl/bin/proj_thresh"  \
+    --exclude "fsl/bin/midtrans"  \
+    --exclude "fsl/binfsl_histogram"  \
+    --exclude "fsl/bin/pulse"  \
+    --exclude "fsl/bin/possum"  \
+    --exclude "fsl/bin/asl_mfree"  \
+    --exclude "fsl/bin/fugue"  \
+    --exclude "fsl/bin/asl_file"  \
+    --exclude "fsl/bin/fast"  \
+    --exclude "fsl/bin/ccops"  \
+    --exclude "fsl/bin/swap_subjectwise"  \
+    --exclude "fsl/bin/swap_voxelwise"  \
+    --exclude "fsl/bin/estimate_metric_distortion"  \
+    --exclude "fsl/bin/prelude"  \
+    --exclude "fsl/bin/betsurf"  \
+    --exclude "fsl/bin/bet2"  \
+    --exclude "fsl/bin/sigloss"  \
+    --exclude "fsl/bin/pointflirt"  \
+    --exclude "fsl/bin/signal2image"  \
+    --exclude "fsl/bin/xfibres_gpu"  \
+    --exclude "fsl/bin/pnm_evs"  \
+    --exclude "fsl/bin/b0calc"  \
+    --exclude "fsl/bin/merge_parts_gpu"  \
+    --exclude "fsl/bin/slicer"  \
+    --exclude "fsl/bin/dtigen"  \
+    --exclude "fsl/bin/drawmesh"  \
+    --exclude "fsl/bin/makerot"  \
+    --exclude "fsl/bin/lesion_filling"  \
+    --exclude "fsl/bin/distancemap"  \
+    --exclude "fsl/bin/overlay"  \
+    --exclude "fsl/bin/prewhiten"  \
+    --exclude "fsl/bin/fdr"  \
+    --exclude "fsl/bin/spharm_rm"  \
+    --exclude "fsl/bin/tbss_skeleton"  \
+    --exclude "fsl/binfslcc"  \
+    --exclude "fsl/bin/slicetimer"  \
+    --exclude "fsl/binfslsmoothfill"  \
+    --exclude "fsl/bin/first_mult_bcorr"  \
+    --exclude "fsl/bin/smoothest"  \
+    --exclude "fsl/bin/calc_grad_perc_dev"  \
+    --exclude "fsl/bin/avscale"  \
+    --exclude "fsl/bin/make_dyadic_vectors"  \
+    --exclude "fsl/binfslpspec"  \
+    --exclude "fsl/bin/susan"  \
+    --exclude "fsl/binfslfft"  \
+    --exclude "fsl/bin/unconfound"  \
+    --exclude "fsl/bin/rmsdiff"  \
     && find /opt/fsl-6.0.5.1/data/standard -type f -not -name "MNI152_T1_2mm_brain.nii.gz" -delete
 ENV FSLDIR="/opt/fsl-6.0.5.1" \
     PATH="/opt/fsl-6.0.5.1/bin:$PATH" \
@@ -88,11 +187,11 @@ ENV PATH="/opt/afni-latest:$PATH" \
 ENV ANTSPATH="/opt/ants" \
     PATH="/opt/ants:$PATH"
 WORKDIR $ANTSPATH
-RUN curl -sSL "https://dl.dropbox.com/s/gwf51ykkk5bifyj/ants-Linux-centos6_x86_64-v2.3.4.tar.gz" \
+RUN curl -sSL --retry 5 "https://dl.dropbox.com/s/gwf51ykkk5bifyj/ants-Linux-centos6_x86_64-v2.3.4.tar.gz" \
     | tar -xzC $ANTSPATH --strip-components 1
 
 # Create a shared $HOME directory
-RUN useradd -m -s /bin/bash -G users cabinet
+RUN useradd -m -s /bin/bash -G users -u 1000 cabinet
 WORKDIR /home/cabinet
 ENV HOME="/home/cabinet" \
     LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
@@ -115,16 +214,12 @@ ENV RESULTS_FOLDER="/opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models"
 
 RUN mkdir -p /opt/nnUNet/nnUNet_raw_data_base/ /opt/nnUNet/nnUNet_raw_data_base/nnUNet_preprocessed /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet /home/cabinet/data
 #COPY trained_models/Task512_BCP_ABCD_Neonates_SynthSegDownsample.zip /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet
-RUN wget https://s3.msi.umn.edu/CABINET_data/Task552_uniform_distribution_synthseg.zip -O /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet/Task552_uniform_distribution_synthseg.zip && \
-    wget https://s3.msi.umn.edu/CABINET_data/Task514_BCP_ABCD_Neonates_SynthSeg_T1Only.zip -O /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet/Task514_BCP_ABCD_Neonates_SynthSeg_T1Only.zip && \
-    wget https://s3.msi.umn.edu/CABINET_data/Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.zip -O /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet/Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.zip
-RUN cd /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet && \
-    unzip -qq Task552_uniform_distribution_synthseg.zip && \
-    rm Task552_uniform_distribution_synthseg.zip && \
-    unzip -qq Task514_BCP_ABCD_Neonates_SynthSeg_T1Only.zip && \
-    rm Task514_BCP_ABCD_Neonates_SynthSeg_T1Only.zip && \
-    unzip -qq Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.zip && \
-    rm Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.zip
+RUN curl -sSL "https://s3.msi.umn.edu/cabinet-data-targz/Task552_uniform_distribution_synthseg.tar.gz" | tar -xzC /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet --no-same-owner --strip-components 1 && \
+    curl -sSL "https://s3.msi.umn.edu/cabinet-data-targz/Task514_BCP_ABCD_Neonates_SynthSeg_T1Only.tar.gz" | tar -xzC /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet --no-same-owner --strip-components 1 && \
+    curl -sSL "https://s3.msi.umn.edu/cabinet-data-targz/Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.tar.gz" | tar -xzC /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet --no-same-owner --strip-components 1
+
+RUN curl -sSL "https://dl.dropbox.com/s/gwf51ykkk5bifyj/ants-Linux-centos6_x86_64-v2.3.4.tar.gz" \
+    | tar -xzC $ANTSPATH --strip-components 1
 
 COPY run.py /home/cabinet/run.py
 COPY src /home/cabinet/src
@@ -132,7 +227,7 @@ RUN chmod 777 -R /opt/fsl-6.0.5.1
 RUN bash /home/cabinet/src/fixpy.sh /opt/fsl-6.0.5.1
 COPY bin /home/cabinet/bin
 #COPY data /home/cabinet/data
-RUN wget https://s3.msi.umn.edu/CABINET_data/data.zip -O /home/cabinet/data/temp_data.zip && cd /home/cabinet/data && unzip -qq temp_data.zip && rm temp_data.zip
+RUN curl -sSL "https://s3.msi.umn.edu/cabinet-data-targz/data.tar.gz" | tar -xzC /home/cabinet/data --no-same-owner --strip-components 1
 
 COPY parameter-file-application.json /home/cabinet/parameter-file-application.json
 COPY parameter-file-container.json /home/cabinet/parameter-file-container.json
@@ -144,6 +239,9 @@ RUN cp /home/cabinet/run.py /home/cabinet/cabinet
 
 RUN cd /home/cabinet/ && pip install -r requirements.txt 
 RUN cd /home/cabinet/ && chmod 555 -R run.py bin src parameter-file-application.json parameter-file-container.json cabinet data
-RUN chmod 666 /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet/3d_fullres/Task*/nnUNetTrainerV2__nnUNetPlansv2.1/postprocessing.json
+RUN find /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet/3d_fullres -type f -name 'postprocessing.json' -exec chmod 666 {} \;
+
+# Remap ownership of files with UIDs above 65535 to user "cabinet" (excluding files in mounted locations)
+RUN find / -type f -uid +65535 -exec chown cabinet:cabinet {} \; -mount
 
 ENTRYPOINT ["cabinet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nvcr.io/nvidia/pytorch:21.11-py3
 
 # Manually update the CABINET version when building
-ENV CABINET_VERSION="2.4.3"
+ENV CABINET_VERSION="2.4.5"
 
 # Prepare environment
 RUN apt-get update && \
@@ -120,8 +120,12 @@ RUN wget https://s3.msi.umn.edu/CABINET_data/Task552_uniform_distribution_synths
     wget https://s3.msi.umn.edu/CABINET_data/Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.zip -O /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet/Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.zip
 RUN cd /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet && \
     unzip -qq Task552_uniform_distribution_synthseg.zip && \
+    rm Task552_uniform_distribution_synthseg.zip && \
     unzip -qq Task514_BCP_ABCD_Neonates_SynthSeg_T1Only.zip && \
-    unzip -qq Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.zip
+    rm Task514_BCP_ABCD_Neonates_SynthSeg_T1Only.zip && \
+    unzip -qq Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.zip && \
+    rm Task515_BCP_ABCD_Neonates_SynthSeg_T2Only.zip
+
 COPY run.py /home/cabinet/run.py
 COPY src /home/cabinet/src
 RUN chmod 777 -R /opt/fsl-6.0.5.1


### PR DESCRIPTION
Reduce disk space needed for Docker build by:
-  Downloading models and data from .tar.gz archives instead of .zip (allows extraction via pipe to tar w/o needing to write the entire archive to disk)
-  Excluding unused FSL binaries

FSL installation is now downloaded from an MSI S3 bucket (was getting frequent timeouts downloading from Oxford mirror)

Add retry on fail to ANTs download

Accomodate CircleCI build testing by excluding host FS attributes from MSI S3-hosted files (i.e. UID/GID, which must be in the range 0-65535 for CircleCI)

Added config.yml for CircleCI build 

Updated model directory contents for tasks 514, 515

