### PR TITLE
Iterative chirality correction

### DIFF
--- a/src/postbibsnet.py
+++ b/src/postbibsnet.py
@@ -249,7 +249,7 @@ def create_crude_LR_mask(sub_ses, j_args):
     modified_data[:midpoint_x, :, :][data[:midpoint_x, :, :] > 0] = 1
     modified_data[midpoint_x:, :, :][data[midpoint_x:, :, :] > 0] = 2
 
-    nib.save(img, seg_BIBSnet_outfiles[0])
+    #nib.save(img, seg_BIBSnet_outfiles[0])
     save_nifti(modified_data, affine, crude_left_right_mask_nifti_fpath)
 
     return crude_left_right_mask_nifti_fpath

--- a/src/postbibsnet.py
+++ b/src/postbibsnet.py
@@ -234,10 +234,16 @@ def create_crude_LR_mask(sub_ses, j_args):
     # Get BIBSnet output file, and if there are multiple, then raise an error
     out_BIBSnet_seg = os.path.join(j_args["optional_out_dirs"]["bibsnet"],
                                    *sub_ses, "output", "*.nii.gz")
+    seg_BIBSnet_outfiles = glob(out_BIBSnet_seg)
+    if len(seg_BIBSnet_outfiles) != 1:
+        LOGGER.error(f"There must be exactly one BIBSnet segmentation file: "
+                     "{}\nResume at postBIBSnet stage once this is fixed."
+                     .format(out_BIBSnet_seg))
+        sys.exit()
     
     crude_left_right_mask_nifti_fpath = os.path.join(outdir_LR_reg, "crude_LRmask.nii.gz")
 
-    img = nib.load(out_BIBSnet_seg)
+    img = nib.load(seg_BIBSnet_outfiles[0])
     data = img.get_fdata()
     affine = img.affine
     
@@ -249,8 +255,8 @@ def create_crude_LR_mask(sub_ses, j_args):
     modified_data[:midpoint_x, :, :][data[:midpoint_x, :, :] > 0] = 1
     modified_data[midpoint_x:, :, :][data[midpoint_x:, :, :] > 0] = 2
 
-    nib.save(img, out_BIBSnet_seg)
-    save_nifti(modified_data, affine, left_right_mask_nifti_fpath)
+    nib.save(img, seg_BIBSnet_outfiles[0])
+    save_nifti(modified_data, affine, crude_left_right_mask_nifti_fpath)
 
     return crude_left_right_mask_nifti_fpath
 

--- a/src/postbibsnet.py
+++ b/src/postbibsnet.py
@@ -122,14 +122,8 @@ def run_postBIBSnet(j_args):
 
     return j_args
 
-    # Write j_args out to csv
-    j_args_csv = 'j_args.csv'
-    with open(j_args_csv, 'w', newline='') as csvfile:
-        csv_writer = csv.writer(csvfile)
-        csv_writer.writerow(['Key', 'Value'])
-        for key, value in j_args.items():
-            csv_writer.writerow([key, value])
-
+    # Write j_args out to logs
+    LOGGER.debug(j_args)
 
 def run_correct_chirality(l_r_mask_nifti_fpath, j_args):
     """

--- a/src/postbibsnet.py
+++ b/src/postbibsnet.py
@@ -215,9 +215,9 @@ def create_crude_LR_mask(sub_ses, j_args):
     midpoint_x = data.shape[0] // 2
     modified_data = np.zeros_like(data)
     
-    # Assign value 1 to left-side voxels with values greater than 0 value 2 to right-side voxels with values greater than 0
-    modified_data[:midpoint_x, :, :][data[:midpoint_x, :, :] > 0] = 1
-    modified_data[midpoint_x:, :, :][data[midpoint_x:, :, :] > 0] = 2
+    # Assign value 1 to right-side voxels with values greater than 0 value 2 to left-side voxels with values greater than 0 (note that these actually correspond to left and right brain hemispheres respectively)
+    modified_data[midpoint_x:, :, :][data[midpoint_x:, :, :] > 0] = 1
+    modified_data[:midpoint_x, :, :][data[:midpoint_x, :, :] > 0] = 2
 
     #nib.save(img, seg_BIBSnet_outfiles[0])
     save_nifti(modified_data, affine, crude_left_right_mask_nifti_fpath)


### PR DESCRIPTION
these updates perform chirality correction in an iterative fashion. the first correction uses a crude LR mask created from splitting the image into left and right from the center of the image in the coronal plain. the second correction uses the more refined LR mask generated with registration to templates (the current method)

This won't impact the midline chirality issues in any way, but it does catch any superficial brain regions outside of the midline. It's a simple update that shouldn't negatively impact anything and also requires an inconsequential amount of additional computing resources/time

I've tested the container and it works as expected