### PR TITLE
Fixed incorrect docker command, changed /out to /output

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,7 +111,7 @@ This has been primarily tested in Singularity. We are less able to provide techn
 
     docker run --rm -it \
     -v /path/to/input:/input \
-    -v /path/to/output:/out \
+    -v /path/to/output:/output \
     docker_image:version /input /output participant -v
 
 #### Singularity


### PR DESCRIPTION
The docker command on the 'usage' page of readthedocs pairs the user's directory to docker directory '/out', but then the argument referring to this directory later in the command is '/output' (which throws an error)