### PR TITLE
FIX: extend read/execute permissions to all files used by BIBSnet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,6 @@ RUN cp /home/bibsnet/run.py /home/bibsnet/bibsnet
 RUN cd /home/bibsnet/ && pip install -v -r requirements.txt
 RUN pip list | grep pandas
 RUN python -c "import pandas; print(pandas.__version__)"
-RUN cd /home/bibsnet/ && chmod 555 -R run.py src bibsnet
+RUN chmod -R a+rx /home/bibsnet /opt/nnUNet
 
 ENTRYPOINT ["bibsnet"]


### PR DESCRIPTION
Fixes #132
Fixes #133
 
Since the devs are already giving all users read+execute permissions to all files in `/home/bibsnet/src`, I am assuming that it is okay with the devs to extend this to `/home/bibsnet/data` and `/opt/nnUNet`

-----------------------------

#### Long story:


Both of the linked issues arose from file permission issues, specifically for `users` who are in the `others` permission group (i.e. not in the `user` or `group` groups).

For example, on `main`, if you enter into the docker container with:

`docker run -it --entrypoint /bin/bash dcanumn/bibsnet:latest`

OR

`singularity shell --nv --cleanenv --no-home  /home/path/to/bibsnet.sif`

 These are the permissions for `/home/bibsnet/data`:

```bash
ls -l /home/bibsnet/data
```

```console

drwxrws--- 2 77661 12710 4096 Aug 26  2022 MNI_templates
-rwxrwx--- 1 77661 12710 1370 Aug 26  2022 age_to_avg_head_radius_BCP.csv
-rwxrwx--- 1 77661 12710  295 Aug 26  2022 dataset_description.json
-rwxrwx--- 1 77661 12710   32 Aug 26  2022 identity_matrix.mat
drwxrws--- 2 77661 12710 4096 Aug 26  2022 look_up_tables
-rwxrwx--- 1 77661 12710  713 Aug 14 16:28 models.csv
-rwxrwx--- 1 77661 12710  295 Mar 28 21:29 sidecar_template.json
```

- `models.csv` is unreadable for users in the `others` permission group. This causes bibsnet to crash: #132


And:

```bash
ls -l /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet/3d_fullres/
```

In the docker image I get:

```console
drwxrwsr-- 3 77661 12710 4096 Aug 15 15:19 Task540
drwxrwsr-- 3 77661 12710 4096 Aug 15 15:18 Task541
drwxrwsr-- 3 77661 12710 4096 Aug 15 15:18 Task542
```

But in the singularity image I get:

```console
d????????? ? ? ? ?            ? Task540
```

- Ditto, these model directories are not readable for users in the `others` permission group. This causes BIBSnet to crash with an error message that was hard to interpret: `RuntimeError: Could not find a task with the ID 541.`: #133

--------------------------------------------------------------------

This was a really nasty one to debug.... I think it might be worth including a test that asserts that all files needed by BIBSnet give read+execute permissions to all users, to avoid a code regression in the future.

