### PR TITLE
Docker build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pennbbl/qsiprep-freesurfer:23.3.0 as build_freesurfer
 FROM build_pytorch
 # Manually update the BIBSnet version when building
 
-ENV BIBSNET_VERSION="3.5.0"
+ENV BIBSNET_VERSION="3.5.1"
 
 # Prepare environment
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,12 @@ FROM pennbbl/qsiprep-freesurfer:23.3.0 as build_freesurfer
 FROM build_pytorch
 # Manually update the BIBSnet version when building
 
-ENV BIBSNET_VERSION="3.5.1"
-ENV BIBSNET_VERSION_MINOR="3.5"
+
 ENV BIBSNET_VERSION_MAJOR="3"
+ENV BIBSNET_VERSION_MINOR="5"
+ENV BIBSNET_VERSION_PATCH="1"
+ENV BIBSNET_VERSION="${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.${BIBSNET_VERSION_PATCH}"
+
 
 # Prepare environment
 RUN apt-get update && \
@@ -57,10 +60,10 @@ RUN apt-get update -qq \
     && rm -rf /var/lib/apt/lists/* \
     && echo "Downloading FSL ..." \
     && mkdir -p /opt/fsl-6.0.5.1 \
-    && wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" \
-    && tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz fsl-6.0.5.1-centos7_64.tar.gz \
+    && wget -O bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz" \
+    && tar -xzf bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz fsl-6.0.5.1-centos7_64.tar.gz \
     && tar -xzf fsl-6.0.5.1-centos7_64.tar.gz -C /opt/fsl-6.0.5.1 --no-same-owner --strip-components 1 \
-    && rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz fsl-6.0.5.1-centos7_64.tar.gz
+    && rm bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz fsl-6.0.5.1-centos7_64.tar.gz
 
 ENV FSLDIR="/opt/fsl-6.0.5.1" \
     PATH="/opt/afni-latest:/opt/ants:/opt/fsl-6.0.5.1/bin:$PATH" \
@@ -99,10 +102,10 @@ RUN chmod a+rx /opt/freesurfer/bin/mri_synthseg /opt/freesurfer/bin/mri_synthstr
 # Installing ANTs 2.3.3 (NeuroDocker build)
 RUN echo "Downloading ANTs ..." && \
     mkdir -p /opt/ants && \
-    wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" && \
-    tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz ants-Linux-centos6_x86_64-v2.3.4.tar.gz && \
+    wget -O bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz" && \
+    tar -xzf bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz ants-Linux-centos6_x86_64-v2.3.4.tar.gz && \
     tar -xzf ants-Linux-centos6_x86_64-v2.3.4.tar.gz -C /opt/ants --no-same-owner --strip-components 1 && \
-    rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz ants-Linux-centos6_x86_64-v2.3.4.tar.gz
+    rm bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz ants-Linux-centos6_x86_64-v2.3.4.tar.gz
 
 # Create a shared $HOME directory
 RUN useradd -m -s /bin/bash -G users -u 1000 bibsnet
@@ -125,20 +128,20 @@ ENV nnUNet_preprocessed="/opt/nnUNet/nnUNet_raw_data_base/nnUNet_preprocessed" \
 
 RUN mkdir -p /opt/nnUNet/nnUNet_raw_data_base/ /opt/nnUNet/nnUNet_raw_data_base/nnUNet_preprocessed /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet /home/bibsnet/data
 
-RUN wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" && \
-    tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task540_BIBSnet_Production_T1T2_model.tar.gz && \
+RUN wget -O bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz" && \
+    tar -xzf bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz Task540_BIBSnet_Production_T1T2_model.tar.gz && \
     tar -xzf Task540_BIBSnet_Production_T1T2_model.tar.gz -C /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet --strip-components 1 && \
-    rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task540_BIBSnet_Production_T1T2_model.tar.gz
+    rm bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz Task540_BIBSnet_Production_T1T2_model.tar.gz
 
-RUN wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" && \
-    tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task541_BIBSnet_Production_T1only_model.tar.gz && \
+RUN wget -O bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz" && \
+    tar -xzf bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz Task541_BIBSnet_Production_T1only_model.tar.gz && \
     tar -xzf Task541_BIBSnet_Production_T1only_model.tar.gz -C /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet --strip-components 1 && \
-    rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task541_BIBSnet_Production_T1only_model.tar.gz
+    rm bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz Task541_BIBSnet_Production_T1only_model.tar.gz
 
-RUN wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" && \
-    tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task542_BIBSnet_Production_T2only_model.tar.gz && \
+RUN wget -O bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz" && \
+    tar -xzf bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz Task542_BIBSnet_Production_T2only_model.tar.gz && \
     tar -xzf Task542_BIBSnet_Production_T2only_model.tar.gz -C /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet --strip-components 1 && \
-    rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task542_BIBSnet_Production_T2only_model.tar.gz
+    rm bibsnet-${BIBSNET_VERSION_MAJOR}.${BIBSNET_VERSION_MINOR}.tar.gz Task542_BIBSnet_Production_T2only_model.tar.gz
 
 COPY run.py /home/bibsnet/run.py
 COPY src /home/bibsnet/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN cd /home/bibsnet && \
     mkdir SW && \
     git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
-    git checkout -b 1.7.1-maintenance v1.7.1m4 && \
+    git checkout -b 1.7.1-maintenance v1.7.1m5 && \
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN cd /home/bibsnet && \
     mkdir SW && \
     git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
-    git checkout -b 1.7.1-maintenance v1.7.1m3 && \
+    git checkout -b 1.7.1-maintenance v1.7.1m4 && \
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN cd /home/bibsnet && \
     mkdir SW && \
     git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
-    git checkout -b 1.7.1-maintenance v1.7.1m0 && \
+    git checkout -b 1.7.1-maintenance v1.7.1m1 && \
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN cd /home/bibsnet && \
     git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
     git checkout -b 1.7.1-maintenance v1.7.1m7 && \
+    pip install -v "SimpleITK==2.4.1"
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM build_pytorch
 # Manually update the BIBSnet version when building
 
 ENV BIBSNET_VERSION="3.5.1"
+ENV BIBSNET_VERSION_MINOR="3.5"
+ENV BIBSNET_VERSION_MAJOR="3"
 
 # Prepare environment
 RUN apt-get update && \
@@ -55,10 +57,10 @@ RUN apt-get update -qq \
     && rm -rf /var/lib/apt/lists/* \
     && echo "Downloading FSL ..." \
     && mkdir -p /opt/fsl-6.0.5.1 \
-    && wget -O bibsnet-$BIBSNET_VERSION.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION.tar.gz" \
-    && tar -xzf bibsnet-$BIBSNET_VERSION.tar.gz fsl-6.0.5.1-centos7_64.tar.gz \
+    && wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" \
+    && tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz fsl-6.0.5.1-centos7_64.tar.gz \
     && tar -xzf fsl-6.0.5.1-centos7_64.tar.gz -C /opt/fsl-6.0.5.1 --no-same-owner --strip-components 1 \
-    && rm bibsnet-$BIBSNET_VERSION.tar.gz fsl-6.0.5.1-centos7_64.tar.gz
+    && rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz fsl-6.0.5.1-centos7_64.tar.gz
 
 ENV FSLDIR="/opt/fsl-6.0.5.1" \
     PATH="/opt/afni-latest:/opt/ants:/opt/fsl-6.0.5.1/bin:$PATH" \
@@ -97,10 +99,10 @@ RUN chmod a+rx /opt/freesurfer/bin/mri_synthseg /opt/freesurfer/bin/mri_synthstr
 # Installing ANTs 2.3.3 (NeuroDocker build)
 RUN echo "Downloading ANTs ..." && \
     mkdir -p /opt/ants && \
-    wget -O bibsnet-$BIBSNET_VERSION.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION.tar.gz" && \
-    tar -xzf bibsnet-$BIBSNET_VERSION.tar.gz ants-Linux-centos6_x86_64-v2.3.4.tar.gz && \
+    wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" && \
+    tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz ants-Linux-centos6_x86_64-v2.3.4.tar.gz && \
     tar -xzf ants-Linux-centos6_x86_64-v2.3.4.tar.gz -C /opt/ants --no-same-owner --strip-components 1 && \
-    rm bibsnet-$BIBSNET_VERSION.tar.gz ants-Linux-centos6_x86_64-v2.3.4.tar.gz
+    rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz ants-Linux-centos6_x86_64-v2.3.4.tar.gz
 
 # Create a shared $HOME directory
 RUN useradd -m -s /bin/bash -G users -u 1000 bibsnet
@@ -123,20 +125,20 @@ ENV nnUNet_preprocessed="/opt/nnUNet/nnUNet_raw_data_base/nnUNet_preprocessed" \
 
 RUN mkdir -p /opt/nnUNet/nnUNet_raw_data_base/ /opt/nnUNet/nnUNet_raw_data_base/nnUNet_preprocessed /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet /home/bibsnet/data
 
-RUN wget -O bibsnet-$BIBSNET_VERSION.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION.tar.gz" && \
-    tar -xzf bibsnet-$BIBSNET_VERSION.tar.gz Task540_BIBSnet_Production_T1T2_model.tar.gz && \
+RUN wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" && \
+    tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task540_BIBSnet_Production_T1T2_model.tar.gz && \
     tar -xzf Task540_BIBSnet_Production_T1T2_model.tar.gz -C /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet --strip-components 1 && \
-    rm bibsnet-$BIBSNET_VERSION.tar.gz Task540_BIBSnet_Production_T1T2_model.tar.gz
+    rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task540_BIBSnet_Production_T1T2_model.tar.gz
 
-RUN wget -O bibsnet-$BIBSNET_VERSION.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION.tar.gz" && \
-    tar -xzf bibsnet-$BIBSNET_VERSION.tar.gz Task541_BIBSnet_Production_T1only_model.tar.gz && \
+RUN wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" && \
+    tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task541_BIBSnet_Production_T1only_model.tar.gz && \
     tar -xzf Task541_BIBSnet_Production_T1only_model.tar.gz -C /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet --strip-components 1 && \
-    rm bibsnet-$BIBSNET_VERSION.tar.gz Task541_BIBSnet_Production_T1only_model.tar.gz
+    rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task541_BIBSnet_Production_T1only_model.tar.gz
 
-RUN wget -O bibsnet-$BIBSNET_VERSION.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION.tar.gz" && \
-    tar -xzf bibsnet-$BIBSNET_VERSION.tar.gz Task542_BIBSnet_Production_T2only_model.tar.gz && \
+RUN wget -O bibsnet-$BIBSNET_VERSION_MINOR.tar.gz "https://s3.msi.umn.edu/bibsnet-data/bibsnet-$BIBSNET_VERSION_MINOR.tar.gz" && \
+    tar -xzf bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task542_BIBSnet_Production_T2only_model.tar.gz && \
     tar -xzf Task542_BIBSnet_Production_T2only_model.tar.gz -C /opt/nnUNet/nnUNet_raw_data_base/nnUNet_trained_models/nnUNet --strip-components 1 && \
-    rm bibsnet-$BIBSNET_VERSION.tar.gz Task542_BIBSnet_Production_T2only_model.tar.gz
+    rm bibsnet-$BIBSNET_VERSION_MINOR.tar.gz Task542_BIBSnet_Production_T2only_model.tar.gz
 
 COPY run.py /home/bibsnet/run.py
 COPY src /home/bibsnet/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,9 +111,9 @@ ENV HOME="/home/bibsnet" \
 # install nnUNet git repo
 RUN cd /home/bibsnet && \
     mkdir SW && \
-    git clone https://github.com/MIC-DKFZ/nnUNet.git && \
+    git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
-    git checkout -b v1.7.1 v1.7.1 && \
+    git checkout -b 1.7.1-maintenance v1.7.1m0 && \
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN cd /home/bibsnet && \
     mkdir SW && \
     git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
-    git checkout -b 1.7.1-maintenance v1.7.1m6 && \
+    git checkout -b 1.7.1-maintenance v1.7.1m7 && \
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN cd /home/bibsnet && \
     mkdir SW && \
     git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
-    git checkout -b 1.7.1-maintenance v1.7.1m5 && \
+    git checkout -b 1.7.1-maintenance v1.7.1m6 && \
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN cd /home/bibsnet && \
     mkdir SW && \
     git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
-    git checkout -b 1.7.1-maintenance v1.7.1m1 && \
+    git checkout -b 1.7.1-maintenance v1.7.1m2 && \
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ RUN cd /home/bibsnet && \
     git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
     git checkout -b 1.7.1-maintenance v1.7.1m7 && \
-    pip install -v "SimpleITK==2.4.1"
+    pip install -v "SimpleITK==2.4.1" && \
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN cd /home/bibsnet && \
     mkdir SW && \
     git clone https://github.com/DCAN-Labs/nnUNet.git && \
     cd nnUNet && \
-    git checkout -b 1.7.1-maintenance v1.7.1m2 && \
+    git checkout -b 1.7.1-maintenance v1.7.1m3 && \
     pip install -e .
 
 #ENV nnUNet_raw_data_base="/output"


### PR DESCRIPTION
Fix for Docker build issues related to nnUnet and its dependencies.

- Install SimpleITK==2.4.1 before nnUnet (to prevent the dependency chain of nnUnet -> medpy -> SimpleITK attempting to install SimpleITK 2.5.x, which will fail)
- Install nnUnet from the "1.7.1-maintenance" branch of the DCAN-Labs fork, which sets upper version limits for several dependencies based on those known to work in BIBSNet 3.5.0.
- Bump BIBSnet version string to 3.5.1   